### PR TITLE
Allow symfony/twig-bundle ^5.4 to better test lowest deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,9 @@
         "symfony/phpunit-bridge": "^5.4|^6.3|^7.0",
         "phpstan/phpstan": "^1.11",
         "zenstruck/browser": "^1.4",
-        "symfony/twig-bundle": "^6.3|^7.0",
-        "twig/twig": "^2.15|^3.0"
+        "symfony/twig-bundle": "^5.4|^6.3|^7.0",
+        "twig/twig": "^2.15|^3.0",
+        "symfony/options-resolver": "^5.4|^6.3|^7.0"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/DynamicFormBuilder.php
+++ b/src/DynamicFormBuilder.php
@@ -191,7 +191,10 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
         return $this->builder->count();
     }
 
-    public function add(string|FormBuilderInterface $child, string $type = null, array $options = []): static
+    /**
+     * @param string|FormBuilderInterface $child
+     */
+    public function add($child, string $type = null, array $options = []): static
     {
         $this->builder->add($child, $type, $options);
 
@@ -286,7 +289,7 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
         return $this;
     }
 
-    public function setDataMapper(?DataMapperInterface $dataMapper): static
+    public function setDataMapper(DataMapperInterface $dataMapper = null): static
     {
         $this->builder->setDataMapper($dataMapper);
 
@@ -335,7 +338,10 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
         return $this;
     }
 
-    public function setPropertyPath(null|string|PropertyPathInterface $propertyPath): static
+    /**
+     * @param string|PropertyPathInterface|null $propertyPath
+     */
+    public function setPropertyPath($propertyPath): static
     {
         $this->builder->setPropertyPath($propertyPath);
 


### PR DESCRIPTION
In order to prevent regression and catch #5 with tests... needed to be rebased on #7 to make tests pass.

Seems we also need to add `"symfony/options-resolver": "^5.4|^6.3|^7.0"` to the dev deps to fix deprecations