### PR TITLE
docs: requestSubmit for turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ class FeedbackForm extends AbstractType
                 'Terrible' => 1
             ],
 +           // This will allow the form to auto-submit on value change
-+           'attr' => ['onchange' => 'this.form.submit()'],
++           'attr' => ['onchange' => 'this.form.requestSubmit()'],
         ]);
 +       // This will allow to differenciate between a user submition and an auto-submit
 +       $builder->add('submit', SubmitType::class, [


### PR DESCRIPTION
Hey,

With `this.form.submit()` the form submission is not handled by turbo and the whole page refreshes.

I found https://discuss.hotwired.dev/t/form-submit-with-turbo-streams-response-without-redirect/3290/2 with a working solution: replacing `this.form.submit()` with `this.form.requestSubmit()`.

