### PR TITLE
fix: ensure dependent field values are set to null when removed

### DIFF
--- a/src/DynamicFormBuilder.php
+++ b/src/DynamicFormBuilder.php
@@ -137,6 +137,7 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
                 $name = $dependentFieldConfig->name;
 
                 if (!$dynamicField->shouldBeAdded()) {
+                    $availableDependencyData[$name] = null;
                     $this->form->remove($name);
 
                     continue;


### PR DESCRIPTION
- Updated `executeReadyCallbacks` method to set the value of dependent fields to `null` before removing them from the form.
- This prevents outdated or invalid data from being retained when fields are dynamically removed based on form dependencies.
- Improved handling of nested dependencies where a field depends on another dependent field that might no longer exist.
