### PR TITLE
feat: check ci for symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/options-resolver": "^5.4|^6.3|^7.0|^8.0",
         "phpunit/phpunit": "^9.6"
     },
-    "minimum-stability": "beta",
+    "minimum-stability": "dev",
     "prefer-stable": false,
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Just a check

needs to be reverted.

"minimum-stability": "beta",
"prefer-stable": false,