### PR TITLE
feat: revert prefer-stable: false

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpunit/phpunit": "^9.6"
     },
     "minimum-stability": "dev",
-    "prefer-stable": false,
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Symfonycasts\\DynamicForms\\": "src"


### PR DESCRIPTION
now after stable releases of symfony 8, this could be reverted to true