### PR TITLE
ModelTransformer and ViewTransformer support

### DIFF
--- a/src/DependentField.php
+++ b/src/DependentField.php
@@ -9,6 +9,8 @@
 
 namespace Symfonycasts\DynamicForms;
 
+use Symfony\Component\Form\DataTransformerInterface;
+
 /**
  * Used to configure a dependent/dynamic field.
  *
@@ -19,6 +21,16 @@ class DependentField
     private ?string $type = null;
     private array $options = [];
     private bool $shouldBeAdded = false;
+
+    /**
+     * @var DataTransformerInterface[]
+     */
+    private array $modelTransformers;
+
+    /**
+     * @var DataTransformerInterface[]
+     */
+    private array $viewTransformers;
 
     public function add(?string $type = null, array $options = []): static
     {
@@ -42,5 +54,35 @@ class DependentField
     public function shouldBeAdded(): bool
     {
         return $this->shouldBeAdded;
+    }
+
+    public function addModelTransformer(DataTransformerInterface $transformer): self
+    {
+        $this->modelTransformers[] = $transformer;
+
+        return $this;
+    }
+
+    /**
+     * @return DataTransformerInterface[]
+     */
+    public function getModelTransformers(): array
+    {
+        return $this->modelTransformers;
+    }
+
+    public function addViewTransformer(DataTransformerInterface $transformer): self
+    {
+        $this->viewTransformers[] = $transformer;
+
+        return $this;
+    }
+
+    /**
+     * @return DataTransformerInterface[]
+     */
+    public function getViewTransformers(): array
+    {
+        return $this->viewTransformers;
     }
 }

--- a/src/DynamicFormBuilder.php
+++ b/src/DynamicFormBuilder.php
@@ -149,8 +149,8 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
                     $fieldBuilder->addModelTransformer($modelTransformer);
                 }
 
-                foreach ($dynamicField->getViewTransformers() as $modelTransformer) {
-                    $fieldBuilder->addViewTransformer($modelTransformer);
+                foreach ($dynamicField->getViewTransformers() as $viewTransformer) {
+                    $fieldBuilder->addViewTransformer($viewTransformer);
                 }
 
                 $this->initializeListeners([$name]);

--- a/src/DynamicFormBuilder.php
+++ b/src/DynamicFormBuilder.php
@@ -143,11 +143,21 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
                 }
 
                 $this->builder->add($name, $dynamicField->getType(), $dynamicField->getOptions());
+                $fieldBuilder = $this->builder->get($name);
+
+                foreach ($dynamicField->getModelTransformers() as $modelTransformer) {
+                    $fieldBuilder->addModelTransformer($modelTransformer);
+                }
+
+                foreach ($dynamicField->getViewTransformers() as $modelTransformer) {
+                    $fieldBuilder->addViewTransformer($modelTransformer);
+                }
 
                 $this->initializeListeners([$name]);
                 // auto initialize mimics FormBuilder::getForm() behavior
-                $field = $this->builder->get($name)->setAutoInitialize(false)->getForm();
-                $this->form->add($field);
+                $fieldBuilder->setAutoInitialize(false);
+
+                $this->form->add($fieldBuilder->getForm());
             }
         }
     }


### PR DESCRIPTION
issue #31 

I added support for ModelTransformer and ViewTransformer

```php
$builder->addDependent('operator', ['filter'], static function (DependentField $field, ?BudgetFilter $budgetFilter): void {
     $field
         ->add(EnumType::class, [])
         ->addModelTransformer(new MyTransformer());
});
```

@bocharsky-bw