### PR TITLE
test: fix Add return type declaration to testDynamicFields method

### DIFF
--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -17,7 +17,7 @@ class FunctionalTest extends KernelTestCase
 {
     use HasBrowser;
 
-    public function testDynamicFields()
+    public function testDynamicFields(): void
     {
         $browser = $this->browser();
         $browser->visit('/form')


### PR DESCRIPTION
Fix PHPStan warning