### PR TITLE
Hide validation errors on dependent fields emptied by a dependency change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "symfony/twig-bundle": "^5.4|^6.3|^7.0|^8.0",
         "twig/twig": "^2.15|^3.0",
         "symfony/options-resolver": "^5.4|^6.3|^7.0|^8.0",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6",
+        "symfony/validator": "^5.4|^6.3|^7.0|^8.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/DynamicFormBuilder.php
+++ b/src/DynamicFormBuilder.php
@@ -46,11 +46,19 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
     private array $preSetDataDependencyData = [];
     private array $postSubmitDependencyData = [];
 
+    /**
+     * Names of the dependencies whose submitted data differs from their initial data.
+     *
+     * @var string[]
+     */
+    private array $changedDependencies = [];
+
     public function __construct(private FormBuilderInterface $builder)
     {
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             $this->form = $event->getForm();
             $this->preSetDataDependencyData = [];
+            $this->changedDependencies = [];
             $this->initializeListeners();
 
             // A fake hidden field where we can "store" an error if a dependent form
@@ -74,6 +82,7 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
         // guarantee later than core ValidationListener
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
             $this->clearDataOnTransformationError($event);
+            $this->clearErrorsOnEmptiedDependentFields($event);
         }, -1);
     }
 
@@ -99,6 +108,16 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
         $dependency = $event->getForm()->getName();
         $this->postSubmitDependencyData[$dependency] = $event->getForm()->getData();
 
+        // remember which dependencies changed during this submit: a dependent
+        // field whose dependency just changed is expected to be emptied by the
+        // UI, so its validation errors should not be rendered (see below)
+        if (\array_key_exists($dependency, $this->preSetDataDependencyData)
+            && $this->preSetDataDependencyData[$dependency] != $this->postSubmitDependencyData[$dependency]
+            && !\in_array($dependency, $this->changedDependencies, true)
+        ) {
+            $this->changedDependencies[] = $dependency;
+        }
+
         $this->executeReadyCallbacks($this->postSubmitDependencyData, FormEvents::POST_SUBMIT);
     }
 
@@ -123,9 +142,57 @@ class DynamicFormBuilder implements FormBuilderInterface, \IteratorAggregate
             // We need to make sure that the form doesn't submit successfully,
             // but we also don't want to render a validation error on any field.
             // So, we jam the error into a hidden field, which doesn't render errors.
-            if ($form->get('__dynamic_error')->isValid()) {
-                $form->get('__dynamic_error')->addError(new FormError('Some dynamic fields have errors.'));
+            $this->addHiddenError($form);
+        }
+    }
+
+    /**
+     * Hides the validation errors of a dependent field that was emptied because
+     * a field it depends on just changed (e.g. user selected "Pizza" as the main
+     * food, then changed "Meal" back and forth: "mainFood" is re-rendered empty,
+     * so a NotBlank-style violation on it is only noise). Like for transformation
+     * failures above, the error is moved to the hidden field: nothing is
+     * rendered, but the form remains invalid.
+     */
+    public function clearErrorsOnEmptiedDependentFields(FormEvent $event): void
+    {
+        if (!$this->changedDependencies) {
+            return;
+        }
+
+        $form = $event->getForm();
+        $errorsCleared = false;
+        foreach ($this->dependentFieldConfigs as $dependentFieldConfig) {
+            if (!array_intersect($dependentFieldConfig->dependencies, $this->changedDependencies)) {
+                continue;
             }
+
+            if (!$form->has($dependentFieldConfig->name)) {
+                continue;
+            }
+
+            $subForm = $form->get($dependentFieldConfig->name);
+            if (!$subForm instanceof ClearableErrorsInterface || !$subForm->isEmpty()) {
+                continue;
+            }
+
+            if (0 === \count($subForm->getErrors(false))) {
+                continue;
+            }
+
+            $subForm->clearErrors();
+            $errorsCleared = true;
+        }
+
+        if ($errorsCleared) {
+            $this->addHiddenError($form);
+        }
+    }
+
+    private function addHiddenError(FormInterface $form): void
+    {
+        if ($form->get('__dynamic_error')->isValid()) {
+            $form->get('__dynamic_error')->addError(new FormError('Some dynamic fields have errors.'));
         }
     }
 

--- a/tests/ConstrainedDependentFieldTest.php
+++ b/tests/ConstrainedDependentFieldTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts DynamicForms package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\DynamicForms\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfonycasts\DynamicForms\Tests\fixtures\DynamicFormsTestKernel;
+use Zenstruck\Browser\Test\HasBrowser;
+
+/**
+ * A dependent field is emptied by the UI whenever one of its dependencies
+ * changes. Its validation errors (e.g. NotBlank) must not be rendered in
+ * that case, in the same way transformation failures are already hidden.
+ *
+ * @see https://github.com/SymfonyCasts/dynamic-forms/issues/50
+ */
+class ConstrainedDependentFieldTest extends KernelTestCase
+{
+    use HasBrowser;
+
+    public function testNoErrorIsRenderedWhenReturningToThePreviousOption(): void
+    {
+        $browser = $this->browser();
+        // pick Dinner, then Pizza
+        $browser->visit('/constrained-form')
+            ->selectFieldOption('Meal', 'Dinner')
+            ->click('Submit Form')
+            ->selectFieldOption('Main food', 'Pizza')
+            ->click('Submit Form')
+            ->assertSee('Is Form Valid: yes')
+        ;
+
+        // change the meal: the submitted "pizza" is not a valid choice anymore,
+        // the transformation failure is hidden but the form is invalid
+        $browser->selectFieldOption('Meal', 'Breakfast')
+            ->click('Submit Form')
+            ->assertSee('Is Form Valid: no')
+            ->assertNotContains('<li')
+        ;
+
+        // change the meal back: "mainFood" is submitted empty, its NotBlank
+        // violation must be hidden too, but the form must remain invalid
+        $browser->selectFieldOption('Meal', 'Dinner')
+            ->click('Submit Form')
+            ->assertSee('Is Form Valid: no')
+            ->assertNotContains('<li')
+        ;
+
+        // selecting a food again makes the form valid
+        $browser->selectFieldOption('Main food', 'Pasta')
+            ->click('Submit Form')
+            ->assertSee('Is Form Valid: yes')
+        ;
+    }
+
+    public function testErrorIsRenderedWhenTheDependencyDidNotChange(): void
+    {
+        $browser = $this->browser();
+        // "Breakfast" is the initial data: submitting it unchanged with an
+        // empty mainFood is a real mistake, the NotBlank violation must render
+        $browser->visit('/constrained-form')
+            ->click('Submit Form')
+            ->assertSee('Is Form Valid: no')
+            ->assertSee('This value should not be blank.')
+        ;
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return DynamicFormsTestKernel::class;
+    }
+}

--- a/tests/fixtures/DynamicFormsTestKernel.php
+++ b/tests/fixtures/DynamicFormsTestKernel.php
@@ -40,6 +40,19 @@ class DynamicFormsTestKernel extends Kernel
         ]));
     }
 
+    public function constrainedForm(Environment $twig, FormFactoryInterface $formFactory, Request $request): Response
+    {
+        $form = $formFactory->create(TestConstrainedDynamicForm::class, [
+            'meal' => DynamicTestMeal::Breakfast,
+        ]);
+        $form->handleRequest($request);
+
+        return new Response($twig->render('form.html.twig', [
+            'form' => $form->createView(),
+            'isFormValid' => $form->isSubmitted() && $form->isValid(),
+        ]));
+    }
+
     public function registerBundles(): iterable
     {
         return [
@@ -78,5 +91,6 @@ class DynamicFormsTestKernel extends Kernel
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
         $routes->add('form', '/form')->controller('kernel::form');
+        $routes->add('constrained_form', '/constrained-form')->controller('kernel::constrainedForm');
     }
 }

--- a/tests/fixtures/TestConstrainedDynamicForm.php
+++ b/tests/fixtures/TestConstrainedDynamicForm.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts DynamicForms package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\DynamicForms\Tests\fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfonycasts\DynamicForms\DependentField;
+use Symfonycasts\DynamicForms\DynamicFormBuilder;
+use Symfonycasts\DynamicForms\Tests\fixtures\Enum\DynamicTestFood;
+use Symfonycasts\DynamicForms\Tests\fixtures\Enum\DynamicTestMeal;
+
+class TestConstrainedDynamicForm extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder = new DynamicFormBuilder($builder);
+
+        $builder->add('meal', EnumType::class, [
+            'class' => DynamicTestMeal::class,
+            'choice_label' => static fn (DynamicTestMeal $meal): string => $meal->getReadable(),
+            'placeholder' => 'Which meal is it?',
+        ]);
+
+        $builder->addDependent('mainFood', ['meal'], static function (DependentField $field, ?DynamicTestMeal $meal) {
+            $field->add(EnumType::class, [
+                'class' => DynamicTestFood::class,
+                'placeholder' => null === $meal ? 'Select a meal first' : \sprintf('What is for %s?', $meal->getReadable()),
+                'choices' => $meal?->getFoodChoices(),
+                'choice_label' => static fn (DynamicTestFood $food): string => $food->getReadable(),
+                'disabled' => null === $meal,
+                'constraints' => [new NotBlank()],
+            ]);
+        });
+    }
+}


### PR DESCRIPTION
Fix #50

When a dependency changes, the UI re-renders its dependent field emptied. The submitted stale value was already handled for **transformation failures**: the error is cleared and moved to the hidden `__dynamic_error` field, so nothing is rendered but the form stays invalid.

Constraint violations were not: returning to a previous option submits the dependent field empty, and a `NotBlank` violation popped up on a field the user never got to fill (the error shown in the issue's video).

This applies the same treatment to violations: when a dependency's submitted data differs from its initial data and the dependent field was submitted empty, its errors are cleared and the hidden error keeps the form invalid. Errors still render when the dependency did not change: submitting the initial value with an empty dependent field is a real mistake, covered by a test.

Ships functional tests on a new fixture form carrying a `NotBlank` constraint (`symfony/validator` added to require-dev), walking the exact A / B / A flow from the issue's video.